### PR TITLE
Updated Thymeleaf Template to enable usage of 'server.servlet.context-path'

### DIFF
--- a/src/main/java/org/sonatype/cs/metrics/SuccessMetricsApplication.java
+++ b/src/main/java/org/sonatype/cs/metrics/SuccessMetricsApplication.java
@@ -42,6 +42,9 @@ public class SuccessMetricsApplication implements CommandLineRunner {
 	@Value("${server.port}")
 	private String port;
 	
+	@Value("${server.servlet.context-path:}")
+	private String contextPath;
+	
 	@Value("${data.includelatestperiod}")
 	private boolean includelatestperiod;
 	
@@ -126,7 +129,7 @@ public class SuccessMetricsApplication implements CommandLineRunner {
 	
 	private void startUp() {
 		if (successMetricsFileLoaded || applicationEvaluationsFileLoaded || policyViolationsDataLoaded || componentsQuarantineLoaded || componentWaiversLoaded){
-			log.info("Ready for viewing at http://localhost:" + port);
+			log.info("Ready for viewing at http://localhost:{}{}", port, contextPath != null ? contextPath : "");
 		}
 		else {
 			log.error("No data files found");

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -4,14 +4,14 @@
     <meta charset="utf-8"/>
     <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
   
-    <script src="webjars/jquery/3.5.1/jquery.min.js"></script>
-    <link href="webjars/bootstrap/4.5.0/css/bootstrap.min.css" rel="stylesheet" />
-    <script src="webjars/bootstrap/4.5.0/js/bootstrap.min.js"></script>
+    <script th:src="@{webjars/jquery/3.5.1/jquery.min.js}"></script>
+    <link th:href="@{webjars/bootstrap/4.5.0/css/bootstrap.min.css}" rel="stylesheet" />
+    <script th:src="@{webjars/bootstrap/4.5.0/js/bootstrap.min.js}"></script>
   
-    <script src="/js/apexcharts.min.js"></script>
-    <link rel="stylesheet" href="/css/apexcharts.css"/>
+    <script th:src="@{/js/apexcharts.min.js}"></script>
+    <link rel="stylesheet" th:href="@{/css/apexcharts.css}"/>
 
-    <link href="/css/main.css" rel="stylesheet"/>
+    <link th:href="@{/css/main.css}" rel="stylesheet"/>
     
     <div class="text-center">
         <img class="displayed" th:src="@{images/sonatype.png}"/>   


### PR DESCRIPTION
When running the spring boot app with the property "server.servlet.context-path" (eg. by using -Dserver.servlet.context-path=/foo) some JS and CSS assets can't be loaded (HTTP 404) because of the additional context-path. This pull request fixes that issue.

Note: I haven't created a new successmetrics.zip, this is up to the repo maintainer.